### PR TITLE
Feature: Add a scaledjob cron trigger for bitbucket

### DIFF
--- a/scaledobject.tf
+++ b/scaledobject.tf
@@ -1,0 +1,41 @@
+resource "kubernetes_manifest" "scaledobject_cron" {
+  for_each = {
+    for runner_name, runner_config in var.bitbucket_runners : runner_name => runner_config
+    if lookup(runner_config, "cron_scaling_enabled", false)
+  }
+
+  manifest = {
+    "apiVersion" = "keda.sh/v1alpha1"
+    "kind"       = "ScaledObject"
+    "metadata"   = {
+      "name"      = "bitbucket-${each.key}"
+      "namespace" = var.k8s_namespace
+    }
+    
+    "spec" = {
+      "scaleTargetRef" = {
+        "name" = "bitbucket-${each.key}"
+      }
+      "minReplicaCount" = 0
+      "maxReplicaCount" = 1
+      "triggers" = [
+        {
+          "type"     = "cron"
+          "metadata" = {
+            "timeZone"        = lookup(each.value, "timeZone", "UTC")
+            "schedule"        = lookup(each.value, "working_hours", "0 6-23 * * 1-5")
+            "desiredReplicas" = "1"
+          }
+        },
+        {
+          "type"     = "cron"
+          "metadata" = {
+            "timeZone"        = lookup(each.value, "timeZone", "UTC")
+            "schedule"        = lookup(each.value, "non_working_hours", "0 0-5 * * 1-5, 0-23 * * 6, 0-23 * * 7")
+            "desiredReplicas" = "0"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,10 @@ variable "bitbucket_runners" {
         memory = optional(string)
       }))
     }))
+    cron_scaling_enabled = optional(bool, false)
+    timeZone             = optional(string, "UTC")
+    working_hours        = optional(string, "0 6-23 * * 1-5")
+    non_working_hours    = optional(string, "0 0-5 * * 1-5,0-23 * * 6,0-23 * * 7")
   }))
   description = "Map of Bitbucket runner definitions"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
- Adds a KEDA cron trigger to turn off specific machines while off working hours / days

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/skyscrapers/joyn/issues/335
- When working on the above issue, I was looking at the tools cluster for Joyn, and noticed they can immensely benefit from this feature.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Help customers save 💰 

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Not tested, would like to be triple checked first

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
